### PR TITLE
fix compatible runtime for latest serveless version

### DIFF
--- a/seleniumLayer/serverless.yml
+++ b/seleniumLayer/serverless.yml
@@ -11,15 +11,13 @@ provider:
 layers:
   selenium:
     path: selenium
-    CompatibleRuntimes: [
-      "python3.6"
-    ]
+    compatibleRuntimes:
+      - "python3.6"
   chromedriver:
     path: chromedriver
     description: chrome driver layer
-    CompatibleRuntimes: [
-      "python3.6"
-    ]
+    compatibleRuntimes:
+      - "python3.6"
 resources:
   Outputs:
     SeleniumLayerExport:


### PR DESCRIPTION
It seems to change `CompatibleRuntimes` config for the latest version.

![image](https://user-images.githubusercontent.com/1635118/74487009-c19bdb80-4f01-11ea-8d9a-3aec6c1eb9c0.png)

https://serverless.com/framework/docs/providers/aws/guide/layers/#aws---layers